### PR TITLE
Fix data race in WithFieldGenerators

### DIFF
--- a/field_generator.go
+++ b/field_generator.go
@@ -26,7 +26,9 @@ func WithFieldGenerators(ctx context.Context, generators ...FieldGenerator) cont
 		return ctx
 	}
 
-	return context.WithValue(ctx, ctxFields, append(FieldGenerators(ctx), generators...))
+	fs := FieldGenerators(ctx)
+	fs = append(make([]FieldGenerator, 0, len(fs)+len(generators)), fs...)
+	return context.WithValue(ctx, ctxFields, append(fs, generators...))
 }
 
 func generateFields(ctx context.Context) []zapcore.Field {

--- a/field_generator_test.go
+++ b/field_generator_test.go
@@ -1,0 +1,49 @@
+package clog
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestFieldGeneratorRace(t *testing.T) {
+	// This test looks for a data race (presumably fixed) in
+	// WithFieldGenerators.
+	//
+	// What happens is WithFieldGenerators will request the slice of
+	// FieldGenerators from a context and append to that slice. When the
+	// slice has more capacity than length, causing WithFieldGenerators to
+	// modify the backing slice's array instead of allocating a new array to
+	// contain the appended items.
+	//
+	// When this happens in parallel across multiple goroutines,
+	// WithFieldGenerators will write to the same backing array, creating
+	// a data race between the goroutines writing to the array. This depends
+	// on WithFieldGenerators being called enough times that a backing array
+	// is created with extra capacity to account for multiple appends, so
+	// it's dependent on some of the internal behavior on how append selects
+	// the next array's capacity.
+	const goroutines = 3
+
+	ctx := context.Background()
+	ctx = WithFieldGenerators(ctx, make([]FieldGenerator, 13)...)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	// Simulate goroutines sharing a context over parallel tasks, such as
+	// with HTTP requests, by spawning a number of them that branch off of
+	// the same top-level context.
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(ictx context.Context) {
+			defer wg.Done()
+			<-start
+			ictx = WithFieldGenerators(ictx, nil)
+		}(ctx)
+	}
+
+	// Kick off the above goroutines to try to set off a data race.
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
Fix a data race in WithFieldGenerators by ensuring that any call to
WithFieldGenerators makes a copy of the slice associated with the
parent context. This ensures that the backing array between
WithFieldGenerators calls is not shared (except in the case that it's
called with an empty slice), meaning that its append call will no
longer result in possibly writing to extra capacity in the context's
slice.

The context for this is that a recent pull request, #3, introduced
a data race when it added the WithFieldGenerators function to the
package.

To explain what happens, the WithFieldGenerators function works by
appending to the slice of field generators associated with a context.
If the context's associated slice grows enough, append will eventually
give it more capacity than it needs to accomodate further appends. When
that happens, any use of WithFieldGenerators across multiple goroutines
with the same parent context will introduce a data race by writing to
the extra capacity of the slice's backing array. Besides being a data
race, this also means that any data generated by field generators is
unreliable and may be either wrong or cause the program to crash
(by nature of it reading function pointers out of the slice).

An added test, TestFieldGeneratorRace, can be used to test this by
reverting the changes to field_generator.go without removing the test.
A typical scenario for this would be HTTP requests inheriting a base
context and attaching their own data to the slice, and then possibly
spawning additional goroutines on top of that context.

Noticed this while I was checking if there were any upstream changes
I needed to keep for my fork ([go.spiff.io/clog](https://go.spiff.io/clog)) of the package.