### PR TITLE
Update clogdatadog to reference clog v0.2.3

### DIFF
--- a/clogopencensus/clogdatadog/go.mod
+++ b/clogopencensus/clogdatadog/go.mod
@@ -3,7 +3,7 @@ module github.com/Kochava/clog/clogopencensus/clogdatadog
 go 1.15
 
 require (
-	github.com/Kochava/clog v0.2.2
+	github.com/Kochava/clog v0.2.3
 	go.opencensus.io v0.22.6
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0

--- a/clogopencensus/clogdatadog/go.sum
+++ b/clogopencensus/clogdatadog/go.sum
@@ -1,9 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Kochava/clog v0.2.1/go.mod h1:PpuAPz9jDaeiAtVpWFgW2MdeD9Gug6mHV5q5OvkkM3A=
-github.com/Kochava/clog v0.2.2 h1:4xQen++KQII3VbSaeiTWdGH5snZMT1TiijG8yq/7UkQ=
-github.com/Kochava/clog v0.2.2/go.mod h1:PpuAPz9jDaeiAtVpWFgW2MdeD9Gug6mHV5q5OvkkM3A=
+github.com/Kochava/clog v0.2.3 h1:cBrvv5zmpRSQP0yAR9Y1ZcEJ+ts8Vc+R1gTuwo1aVG4=
+github.com/Kochava/clog v0.2.3/go.mod h1:PpuAPz9jDaeiAtVpWFgW2MdeD9Gug6mHV5q5OvkkM3A=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
See https://github.com/Kochava/clog/releases/tag/v0.2.3 and https://github.com/Kochava/clog/pull/6